### PR TITLE
Add products listing endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ POST `/api/auth/login` with JSON body `{ "username": "admin", "password": "passw
 
 The default credentials can be changed by setting the `ADMIN_USER` and
 `ADMIN_PASS` environment variables (see `.env.example`).
+
+## Product Listing
+
+GET `/api/products` returns all stored products.

--- a/src/api/products/controllers.js
+++ b/src/api/products/controllers.js
@@ -1,0 +1,11 @@
+import { service } from './service.js';
+
+const getAll = async (req, res) => {
+  try {
+    res.json(await service.readall());
+  } catch (error) {
+    res.json({ status: 'error', error: error.message });
+  }
+};
+
+export { getAll };

--- a/src/api/products/model.js
+++ b/src/api/products/model.js
@@ -1,0 +1,10 @@
+import mongoose from 'mongoose';
+
+const productSchema = new mongoose.Schema({
+  name: String,
+  price: Number,
+});
+
+const Product = mongoose.model('Product', productSchema);
+
+export { Product };

--- a/src/api/products/routes.js
+++ b/src/api/products/routes.js
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { getAll } from './controllers.js';
+
+const productRoutes = Router();
+
+productRoutes.get('/', getAll);
+
+export { productRoutes };

--- a/src/api/products/service.js
+++ b/src/api/products/service.js
@@ -1,0 +1,9 @@
+import { Product } from './model.js';
+
+const service = {
+  async readall() {
+    return Product.find() ?? [];
+  },
+};
+
+export { service };

--- a/src/api/products/service.test.js
+++ b/src/api/products/service.test.js
@@ -1,0 +1,12 @@
+import mongoose from 'mongoose';
+import { Product } from './model.js';
+import { service } from './service.js';
+
+mongoose.connect('mongodb://127.0.0.1/gateways');
+
+describe('products service', () => {
+  test('readall returns array', async () => {
+    const result = await service.readall();
+    expect(result instanceof Array).toBeTruthy();
+  });
+});

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -2,11 +2,13 @@ import { Router } from "express";
 
 import { gatewayRoutes } from "../api/gateways/routes.js";
 import { authRoutes } from "../api/auth/routes.js";
+import { productRoutes } from "../api/products/routes.js";
 
 const routes = Router();
 
 routes.use("/api/gateways", gatewayRoutes);
 routes.use("/api/auth", authRoutes);
+routes.use("/api/products", productRoutes);
 routes.all("*", (req, res) => {
   res.sendStatus("404");
 });


### PR DESCRIPTION
## Summary
- add Product mongoose model, service, controller and routes
- expose `/api/products` via central router
- document new endpoint
- add basic service test

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406517a0f48328bdc40fe52671a853