### PR TITLE
Add user CRUD endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,13 @@ The default credentials can be changed by setting the `ADMIN_USER` and
 ## Product Listing
 
 GET `/api/products` returns all stored products.
+
+## User CRUD
+
+The API exposes endpoints under `/api/users` to manage user records:
+
+- `GET /api/users` - list all users
+- `GET /api/users/:id` - retrieve a single user by id
+- `POST /api/users` - create a user
+- `PUT /api/users/:id` - update a user
+- `DELETE /api/users/:id` - remove a user

--- a/src/api/users/controllers.js
+++ b/src/api/users/controllers.js
@@ -1,0 +1,51 @@
+import { service } from './service.js';
+
+const getOne = async (req, res) => {
+  try {
+    const id = req.params.id;
+    res.json(await service.readone(id));
+  } catch (error) {
+    res.json({ status: 'error', error: error.message });
+  }
+};
+
+const getAll = async (req, res) => {
+  try {
+    res.json(await service.readall());
+  } catch (error) {
+    res.json({ status: 'error', error: error.message });
+  }
+};
+
+const createUser = async (req, res) => {
+  try {
+    const data = req.body;
+    const result = await service.create(data);
+    res.json(result);
+  } catch (error) {
+    res.json({ status: 'error', error: error.message });
+  }
+};
+
+const updateUser = async (req, res) => {
+  try {
+    const id = req.params.id;
+    const data = req.body;
+    const result = await service.update(id, data);
+    res.json({ status: 'success', data: result });
+  } catch (error) {
+    res.json({ status: 'error', error: error.message });
+  }
+};
+
+const deleteUser = async (req, res) => {
+  try {
+    const id = req.params.id;
+    await service.delete(id);
+    res.json({ status: 'success', response: 'Deleted successfully' });
+  } catch (error) {
+    res.json({ status: 'error', error: error.message });
+  }
+};
+
+export { getOne, getAll, createUser, updateUser, deleteUser };

--- a/src/api/users/model.js
+++ b/src/api/users/model.js
@@ -1,0 +1,11 @@
+import mongoose from 'mongoose';
+
+const userSchema = new mongoose.Schema({
+  username: String,
+  email: String,
+  password: String,
+});
+
+const User = mongoose.model('User', userSchema);
+
+export { User };

--- a/src/api/users/routes.js
+++ b/src/api/users/routes.js
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import { getOne, getAll, createUser, updateUser, deleteUser } from './controllers.js';
+
+const userRoutes = Router();
+
+userRoutes.get('/:id', getOne);
+userRoutes.get('/', getAll);
+userRoutes.post('/', createUser);
+userRoutes.put('/:id', updateUser);
+userRoutes.delete('/:id', deleteUser);
+
+export { userRoutes };

--- a/src/api/users/service.js
+++ b/src/api/users/service.js
@@ -1,0 +1,36 @@
+import { User } from './model.js';
+
+const service = {
+  async readall() {
+    return User.find() ?? [];
+  },
+
+  async readone(id) {
+    if (!id || typeof id !== 'string') throw new Error('Invalid id.');
+    return User.findById(id);
+  },
+
+  async create(data) {
+    if (!data.username || !data.email || !data.password)
+      throw new Error('Invalid input data.');
+
+    const newUser = new User(data);
+    return newUser.save();
+  },
+
+  async update(id, data) {
+    if (!id || typeof id !== 'string') throw new Error('Invalid id.');
+    if (JSON.stringify(data) === '{}') throw new Error('Invalid input data.');
+
+    const { username, email, password } = data;
+    await User.findByIdAndUpdate(id, { username, email, password });
+    return User.findById(id);
+  },
+
+  async delete(id) {
+    if (!id || typeof id !== 'string') throw new Error('Invalid id.');
+    return User.findByIdAndDelete(id);
+  },
+};
+
+export { service };

--- a/src/api/users/service.test.js
+++ b/src/api/users/service.test.js
@@ -1,0 +1,50 @@
+import mongoose from 'mongoose';
+
+import { User } from './model.js';
+import { service } from './service.js';
+
+mongoose.connect('mongodb://127.0.0.1/gateways');
+
+describe('create', () => {
+  test('create user properly', async () => {
+    const result = await service.create({
+      username: 'john',
+      email: 'john@example.com',
+      password: '1234',
+    });
+    expect(result instanceof User).toBeTruthy();
+  });
+
+  test('entry an empty object', async () => {
+    await expect(service.create({})).rejects.toThrow('Invalid input data.');
+  });
+});
+
+describe('getAll', () => {
+  test('get users properly', async () => {
+    const result = await service.readall();
+    expect(result instanceof Array).toBeTruthy();
+  });
+});
+
+describe('getOne', () => {
+  test('type not string id', async () => {
+    await expect(service.readone(123)).rejects.toThrow('Invalid id.');
+  });
+});
+
+describe('update', () => {
+  test('get wrong id', async () => {
+    await expect(service.update(234234, { username: 'a' })).rejects.toThrow('Invalid id.');
+  });
+
+  test('get wrong data', async () => {
+    await expect(service.update('asdasdasd', {})).rejects.toThrow('Invalid input data.');
+  });
+});
+
+describe('delete', () => {
+  test('type not string id', async () => {
+    await expect(service.delete(123)).rejects.toThrow('Invalid id.');
+  });
+});

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -4,6 +4,7 @@ import { Router } from "express";
 import { gatewayRoutes } from "../api/gateways/routes.js";
 import { authRoutes } from "../api/auth/routes.js";
 import { productRoutes } from "../api/products/routes.js";
+import { userRoutes } from "../api/users/routes.js";
 
 // Objeto Router principal que agrupa todas las rutas
 const routes = Router();
@@ -14,6 +15,7 @@ routes.use("/api/gateways", gatewayRoutes);
 routes.use("/api/auth", authRoutes);
 // Endpoints de productos
 routes.use("/api/products", productRoutes);
+routes.use("/api/users", userRoutes);
 routes.all("*", (req, res) => {
   res.sendStatus("404");
 });


### PR DESCRIPTION
## Summary
- implement User model, service, controllers and routes
- wire `/api/users` routes in main router
- document available user endpoints

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f6a4f1b483289be315054c1748f4