### PR TITLE
Fix environment detection

### DIFF
--- a/src/bin/www.js
+++ b/src/bin/www.js
@@ -4,7 +4,9 @@ import app from '../../app.js';
 
 // Script para iniciar el servidor HTTP
 
-process.env.NODE_ENV = 'development';
+if (!process.env.NODE_ENV) {
+        process.env.NODE_ENV = 'development';
+}
 //process.env.TOKEN_SECRET = crypto.randomBytes(64).toString('hex');
 process.env.TOKEN_SECRET =
 	'123456789abcdefghijklmnopqrst.*-+/ABCDEFGHIJKLMNOPQRSTWXYZ0';


### PR DESCRIPTION
## Summary
- allow external config to set `NODE_ENV`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f720191083289969ad4e189076ca