### PR TITLE
Add reports endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ The default credentials can be changed by setting the `ADMIN_USER` and
 
 GET `/api/products` returns all stored products.
 
+## Reports
+
+GET `/api/reports/gateways` returns the total number of gateways and the total number of associated devices.
+
 ## User CRUD
 
 The API exposes endpoints under `/api/users` to manage user records:

--- a/src/api/reports/controllers.js
+++ b/src/api/reports/controllers.js
@@ -1,0 +1,13 @@
+import { service } from './service.js';
+
+// Controller to obtain gateway summary report
+const getGatewaySummary = async (req, res) => {
+  try {
+    const result = await service.gatewaySummary();
+    res.json({ status: 'success', data: result });
+  } catch (error) {
+    res.json({ status: 'error', error: error.message });
+  }
+};
+
+export { getGatewaySummary };

--- a/src/api/reports/routes.js
+++ b/src/api/reports/routes.js
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { getGatewaySummary } from './controllers.js';
+
+const reportRoutes = Router();
+
+// Summary of gateways and total devices
+reportRoutes.get('/gateways', getGatewaySummary);
+
+export { reportRoutes };

--- a/src/api/reports/service.js
+++ b/src/api/reports/service.js
@@ -1,0 +1,16 @@
+import { Gateway } from '../gateways/model.js';
+
+// Service that creates basic summary reports
+const service = {
+  async gatewaySummary() {
+    const gateways = await Gateway.find();
+    const totalGateways = gateways.length;
+    const totalDevices = gateways.reduce(
+      (sum, gw) => sum + (gw.devices ? gw.devices.length : 0),
+      0
+    );
+    return { totalGateways, totalDevices };
+  },
+};
+
+export { service };

--- a/src/api/reports/service.test.js
+++ b/src/api/reports/service.test.js
@@ -1,0 +1,12 @@
+import mongoose from 'mongoose';
+import { service } from './service.js';
+
+mongoose.connect('mongodb://127.0.0.1/gateways');
+
+describe('gatewaySummary', () => {
+  test('returns totals', async () => {
+    const result = await service.gatewaySummary();
+    expect(typeof result.totalGateways).toBe('number');
+    expect(typeof result.totalDevices).toBe('number');
+  });
+});

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -5,6 +5,7 @@ import { gatewayRoutes } from "../api/gateways/routes.js";
 import { authRoutes } from "../api/auth/routes.js";
 import { productRoutes } from "../api/products/routes.js";
 import { userRoutes } from "../api/users/routes.js";
+import { reportRoutes } from "../api/reports/routes.js";
 
 // Objeto Router principal que agrupa todas las rutas
 const routes = Router();
@@ -16,6 +17,7 @@ routes.use("/api/auth", authRoutes);
 // Endpoints de productos
 routes.use("/api/products", productRoutes);
 routes.use("/api/users", userRoutes);
+routes.use("/api/reports", reportRoutes);
 routes.all("*", (req, res) => {
   res.sendStatus("404");
 });


### PR DESCRIPTION
## Summary
- document the new reports route
- add summary reports controller/service/routes
- expose reports route in app routes

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684119491ab083289f87cd8d384be0d9